### PR TITLE
Change area chart color

### DIFF
--- a/app/assets/stylesheets/decidim.scss
+++ b/app/assets/stylesheets/decidim.scss
@@ -50,6 +50,10 @@ body, h1, h2, h3, h4, h5, h6, p, a, span {
   }
 }
 
+.areachart .area {
+ fill: rgba(140,198,63,0.36);
+}
+
 .language-choose {
   // .goog-te-gadget-simple {
   //   border: 0;


### PR DESCRIPTION
This PR aims to change the fill color for area chart metrics, so admins can clearly see the platform's metrics. 

Before
<img width="660" alt="Capture d’écran 2021-06-22 à 12 32 44" src="https://user-images.githubusercontent.com/52420208/122910062-16513100-d356-11eb-9caf-bf52b3aa86bb.png">

After
<img width="994" alt="Capture d’écran 2021-06-22 à 12 33 03" src="https://user-images.githubusercontent.com/52420208/122910065-16e9c780-d356-11eb-9b26-74e4d39f06ae.png">
