### PR TITLE
Change langage menu for Smartling service

### DIFF
--- a/app/assets/stylesheets/decidim.scss
+++ b/app/assets/stylesheets/decidim.scss
@@ -50,46 +50,6 @@ body, h1, h2, h3, h4, h5, h6, p, a, span {
   }
 }
 
-.language-choose {
-  // .goog-te-gadget-simple {
-  //   border: 0;
-  //   font-weight: bold;
-  //   font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
-  // }
-
-  .goog-te-gadget-icon, img {
-    display: none;
-  }
-
-  .goog-te-gadget-simple {
-    border: 0 !important;
-    background-color: transparent;
-
-    a:hover {
-      text-decoration: none;
-    }
-
-    span {
-      border: 0 !important;
-
-      span:first-child {
-        font-size: 1rem;
-        color: #8cc63e;
-        margin-right: 3px;
-
-        &:hover {
-          text-decoration: underline;
-        }
-      }
-
-      span:last-child {
-        color: #e8e8e8 !important;
-      }
-    }
-  }
-}
-
-
 
 @media screen and (max-width: 39.99875em) {
   .title-bar {

--- a/app/views/layouts/decidim/_language_chooser.html.erb
+++ b/app/views/layouts/decidim/_language_chooser.html.erb
@@ -1,3 +1,79 @@
-<div class="topbar__dropmenu language-choose show-for-medium" data-set="language-holder">
-  <div class="js-append" id="google_translate_element"></div>
+<div class="topbar__dropmenu language-choose sl_norewrite">
+  <ul class="dropdown menu" data-dropdown-menu
+    data-autoclose="false"
+    data-disable-hover="true"
+    data-click-open="true"
+    data-close-on-click="true"
+    tabindex="-1">
+    <li class="is-dropdown-submenu-parent" tabindex="-1">
+      <%= link_to I18n.t("layouts.decidim.language.selector"), "#language-chooser-menu", id: "language-chooser-control", "aria-label": t("layouts.decidim.language_chooser.choose_language"), "aria-controls": "language-chooser-menu", "aria-haspopup": "true" %>
+      <ul class="menu is-dropdown-submenu sl_opaque" id="language-chooser-menu" role="menu" aria-labelledby="language-chooser-control" tabindex="-1">
+        <li>
+          <a href="https://arabic.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.arabic") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://bengali.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.bengali") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://simplifiedchinese.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.simplifiedchinese") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://traditionalchinese.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.traditionalchinese") %>
+          </a>
+        </li>
+        <li class="notranslate">
+          <a href="https://www.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.english") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://french.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.french") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://haitian.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.haitian") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://korean.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.korean") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://polish.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.polish") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://russian.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.russian") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://spanish.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.spanish") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://urdu.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.urdu") %>
+          </a>
+        </li>
+        <li>
+          <a href="https://yiddish.participate.nyc.gov">
+            <%= I18n.t("layouts.decidim.language.yiddish") %>
+          </a>
+        </li>
+      </ul>
+    </li>
+  </ul>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,21 @@ en:
     decidim:
       footer:
         download_open_data: Open data
+      language:
+        selector: Select a language
+        arabic: Arabic
+        bengali: Bengali
+        simplifiedchinese: Simplified chinese
+        traditionalchinese: Traditional chinese
+        english: English
+        french: French
+        haitian: Haitian
+        korean: Korean
+        polish: Polish
+        russian: Russian
+        spanish: Spanish
+        urdu: Urdu
+        yiddish: Yiddish
   omniauth:
     strategies:
       nyc:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -28,3 +28,5 @@ fr:
     decidim:
       footer:
         download_open_data: Données ouvertes
+      language:
+        selector: Sélectionner une langue​

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 namespace :decidim do
-  Rails.logger = Logger.new(STDOUT)
+  # Rails.logger = Logger.new(STDOUT)
   # ActiveRecord::Base.logger = Logger.new(STDOUT)
 
   namespace :db do
@@ -17,7 +17,7 @@ namespace :decidim do
             .where.not(decidim_resource_id: [model.ids])
             .pluck(:event_name, :decidim_resource_id, :extra).count
         end
-        Rails.logger.close
+        # Rails.logger.close
       end
 
       desc "Delete notifications related to orphans data"
@@ -43,7 +43,7 @@ namespace :decidim do
             .where.not(resource_id: [model.ids])
             .pluck(:action, :resource_id, :extra).count
         end
-        Rails.logger.close
+        # Rails.logger.close
       end
 
       desc "Delete admin log related to orphans data"
@@ -66,7 +66,7 @@ namespace :decidim do
           .pluck(:id, :title, :decidim_component_id).each do |s|
             puts s.inspect
           end
-        Rails.logger.close
+        # Rails.logger.close
       end
 
       desc "Delete surveys related to deleted component"
@@ -75,7 +75,7 @@ namespace :decidim do
           .where.not(decidim_component_id: [Decidim::Component.ids])
           .destroy_all
 
-        Rails.logger.close
+        # Rails.logger.close
       end
     end
 


### PR DESCRIPTION
## Context

[participate.nyc.gov](http://participate.nyc.gov) currently uses a google translation plugin to translate all pages.

A custom language selector was implemented

![image](https://user-images.githubusercontent.com/464350/137114435-a507354b-8fec-4e9c-8a0d-e40d24c56365.png)

## Feature request

NYC is implementing [Smartling](https://www.smartling.com/) (similar to Weglot) to implement localization on their website. 

They won't be activating any new languages on their Decidim instance. 

The traffic is redirected via DNS (through sub-domains)

- arabic.participate.nyc.gov
- bengali.participate.nyc.gov
- simplifiedchinese.participate.nyc.gov
- traditionalchinese.participate.nyc.gov
- french.participate.nyc.gov
- haitian.participate.nyc.gov
- korean.participate.nyc.gov
- polish.participate.nyc.gov
- russian.participate.nyc.gov
- spanish.participate.nyc.gov
- urdu.participate.nyc.gov
- yiddish.participate.nyc.gov

## To do

On NYC decidim-app

- [x]  Delete google translate language selector
- [x]  Implement a new language selector using the [Smartling integration](https://help.smartling.com/hc/en-us/articles/360000325254-Implementing-a-Language-Selector)