### PR TITLE
Backport fix geocoded proposals

### DIFF
--- a/.github/workflows/lint_code.yml
+++ b/.github/workflows/lint_code.yml
@@ -1,13 +1,5 @@
 name: "[CI] Lint"
-on:
-  push:
-    branches:
-      - develop
-      - release/*
-      - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+on: "push"
 
 env:
   CI: "true"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,5 @@
 name: Tests
-on:
-  push:
-    branches:
-      - develop
-      - master
-      - release/*
-      - "*-stable"
-  pull_request:
-    branches-ignore:
-      - "chore/l10n*"
+on: "push"
 
 env:
   CI: "true"

--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -1,5 +1,14 @@
 # Overrides
 
+## Fix geocoded map broken when latitude or longitude is NaN
+
+* `app/controllers/decidim/proposals/proposals_controller.rb`
+
+```ruby
+# on line 44
+@all_geocoded_proposals = @base_query.geocoded.where.not(latitude: Float::NAN, longitude: Float::NAN)
+```
+
 ## Update admin settings and fix title bar
 ### Modified
 - **app/views/layouts/decidim/admin/_title_bar.html.erb**

--- a/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/app/controllers/decidim/proposals/proposals_controller.rb
@@ -1,0 +1,297 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Proposals
+    # Exposes the proposal resource so users can view and create them.
+    class ProposalsController < Decidim::Proposals::ApplicationController
+      helper Decidim::WidgetUrlsHelper
+      helper ProposalWizardHelper
+      helper ParticipatoryTextsHelper
+      include Decidim::ApplicationHelper
+      include Flaggable
+      include Withdrawable
+      include FormFactory
+      include FilterResource
+      include Decidim::Proposals::Orderable
+      include Paginable
+
+      helper_method :proposal_presenter, :form_presenter
+
+      before_action :authenticate_user!, only: [:new, :create, :complete]
+      before_action :ensure_is_draft, only: [:compare, :complete, :preview, :publish, :edit_draft, :update_draft, :destroy_draft]
+      before_action :set_proposal, only: [:show, :edit, :update, :withdraw]
+      before_action :edit_form, only: [:edit_draft, :edit]
+
+      before_action :set_participatory_text
+
+      def index
+        if component_settings.participatory_texts_enabled?
+          @proposals = Decidim::Proposals::Proposal
+                       .where(component: current_component)
+                       .published
+                       .not_hidden
+                       .only_amendables
+                       .includes(:category, :scope)
+                       .order(position: :asc)
+          render "decidim/proposals/proposals/participatory_texts/participatory_text"
+        else
+          @base_query = search
+                        .results
+                        .published
+                        .not_hidden
+
+          @proposals = @base_query.includes(:component, :coauthorships)
+          @all_geocoded_proposals = @base_query.geocoded
+
+          @voted_proposals = if current_user
+                               ProposalVote.where(
+                                 author: current_user,
+                                 proposal: @proposals.pluck(:id)
+                               ).pluck(:decidim_proposal_id)
+                             else
+                               []
+                             end
+          @proposals = paginate(@proposals)
+          @proposals = reorder(@proposals)
+        end
+      end
+
+      def show
+        raise ActionController::RoutingError, "Not Found" if @proposal.blank? || !can_show_proposal?
+      end
+
+      def new
+        enforce_permission_to :create, :proposal
+        @step = :step_1
+        if proposal_draft.present?
+          redirect_to edit_draft_proposal_path(proposal_draft, component_id: proposal_draft.component.id, question_slug: proposal_draft.component.participatory_space.slug)
+        else
+          @form = form(ProposalWizardCreateStepForm).from_params(body: translated_proposal_body_template)
+        end
+      end
+
+      def create
+        enforce_permission_to :create, :proposal
+        @step = :step_1
+        @form = form(ProposalWizardCreateStepForm).from_params(proposal_creation_params)
+
+        CreateProposal.call(@form, current_user) do
+          on(:ok) do |proposal|
+            flash[:notice] = I18n.t("proposals.create.success", scope: "decidim")
+
+            redirect_to "#{Decidim::ResourceLocatorPresenter.new(proposal).path}/compare"
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("proposals.create.error", scope: "decidim")
+            render :new
+          end
+        end
+      end
+
+      def compare
+        @step = :step_2
+        @similar_proposals ||= Decidim::Proposals::SimilarProposals
+                               .for(current_component, @proposal)
+                               .all
+
+        if @similar_proposals.blank?
+          flash[:notice] = I18n.t("proposals.proposals.compare.no_similars_found", scope: "decidim")
+          redirect_to "#{Decidim::ResourceLocatorPresenter.new(@proposal).path}/complete"
+        end
+      end
+
+      def complete
+        enforce_permission_to :create, :proposal
+        @step = :step_3
+
+        @form = form_proposal_model
+
+        @form.attachment = form_attachment_new
+      end
+
+      def preview
+        @step = :step_4
+        @form = form(ProposalForm).from_model(@proposal)
+      end
+
+      def publish
+        @step = :step_4
+        PublishProposal.call(@proposal, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("proposals.publish.success", scope: "decidim")
+            redirect_to proposal_path(@proposal)
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("proposals.publish.error", scope: "decidim")
+            render :edit_draft
+          end
+        end
+      end
+
+      def edit_draft
+        @step = :step_3
+        enforce_permission_to :edit, :proposal, proposal: @proposal
+      end
+
+      def update_draft
+        @step = :step_1
+        enforce_permission_to :edit, :proposal, proposal: @proposal
+
+        @form = form_proposal_params
+        UpdateProposal.call(@form, current_user, @proposal) do
+          on(:ok) do |proposal|
+            flash[:notice] = I18n.t("proposals.update_draft.success", scope: "decidim")
+            redirect_to "#{Decidim::ResourceLocatorPresenter.new(proposal).path}/preview"
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("proposals.update_draft.error", scope: "decidim")
+            render :edit_draft
+          end
+        end
+      end
+
+      def destroy_draft
+        enforce_permission_to :edit, :proposal, proposal: @proposal
+
+        DestroyProposal.call(@proposal, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("proposals.destroy_draft.success", scope: "decidim")
+            redirect_to new_proposal_path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("proposals.destroy_draft.error", scope: "decidim")
+            render :edit_draft
+          end
+        end
+      end
+
+      def edit
+        enforce_permission_to :edit, :proposal, proposal: @proposal
+      end
+
+      def update
+        enforce_permission_to :edit, :proposal, proposal: @proposal
+
+        @form = form_proposal_params
+        UpdateProposal.call(@form, current_user, @proposal) do
+          on(:ok) do |proposal|
+            flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
+            redirect_to Decidim::ResourceLocatorPresenter.new(proposal).path
+          end
+
+          on(:invalid) do
+            flash.now[:alert] = I18n.t("proposals.update.error", scope: "decidim")
+            render :edit
+          end
+        end
+      end
+
+      def withdraw
+        enforce_permission_to :withdraw, :proposal, proposal: @proposal
+
+        WithdrawProposal.call(@proposal, current_user) do
+          on(:ok) do
+            flash[:notice] = I18n.t("proposals.update.success", scope: "decidim")
+            redirect_to Decidim::ResourceLocatorPresenter.new(@proposal).path
+          end
+          on(:has_supports) do
+            flash[:alert] = I18n.t("proposals.withdraw.errors.has_supports", scope: "decidim")
+            redirect_to Decidim::ResourceLocatorPresenter.new(@proposal).path
+          end
+        end
+      end
+
+      private
+
+      def search_klass
+        ProposalSearch
+      end
+
+      def default_filter_params
+        {
+          search_text: "",
+          origin: default_filter_origin_params,
+          activity: "all",
+          category_id: default_filter_category_params,
+          state: %w(accepted evaluating state_not_published),
+          scope_id: default_filter_scope_params,
+          related_to: "",
+          type: "all"
+        }
+      end
+
+      def default_filter_origin_params
+        filter_origin_params = %w(citizens meeting)
+        filter_origin_params << "official" if component_settings.official_proposals_enabled
+        filter_origin_params << "user_group" if current_organization.user_groups_enabled?
+        filter_origin_params
+      end
+
+      def proposal_draft
+        Proposal.from_all_author_identities(current_user).not_hidden.only_amendables
+                .where(component: current_component).find_by(published_at: nil)
+      end
+
+      def ensure_is_draft
+        @proposal = Proposal.not_hidden.where(component: current_component).find(params[:id])
+        redirect_to Decidim::ResourceLocatorPresenter.new(@proposal).path unless @proposal.draft?
+      end
+
+      def set_proposal
+        @proposal = Proposal.published.not_hidden.where(component: current_component).find_by(id: params[:id])
+      end
+
+      # Returns true if the proposal is NOT an emendation or the user IS an admin.
+      # Returns false if the proposal is not found or the proposal IS an emendation
+      # and is NOT visible to the user based on the component's amendments settings.
+      def can_show_proposal?
+        return true if @proposal&.amendable? || current_user&.admin?
+
+        Proposal.only_visible_emendations_for(current_user, current_component).published.include?(@proposal)
+      end
+
+      def proposal_presenter
+        @proposal_presenter ||= present(@proposal)
+      end
+
+      def form_proposal_params
+        form(ProposalForm).from_params(params)
+      end
+
+      def form_proposal_model
+        form(ProposalForm).from_model(@proposal)
+      end
+
+      def form_presenter
+        @form_presenter ||= present(@form, presenter_class: Decidim::Proposals::ProposalPresenter)
+      end
+
+      def form_attachment_new
+        form(AttachmentForm).from_model(Attachment.new)
+      end
+
+      def edit_form
+        form_attachment_model = form(AttachmentForm).from_model(@proposal.attachments.first)
+        @form = form_proposal_model
+        @form.attachment = form_attachment_model
+        @form
+      end
+
+      def set_participatory_text
+        @participatory_text = Decidim::Proposals::ParticipatoryText.find_by(component: current_component)
+      end
+
+      def translated_proposal_body_template
+        translated_attribute component_settings.new_proposal_body_template
+      end
+
+      def proposal_creation_params
+        params[:proposal].merge(body_template: translated_proposal_body_template)
+      end
+    end
+  end
+end

--- a/app/controllers/decidim/proposals/proposals_controller.rb
+++ b/app/controllers/decidim/proposals/proposals_controller.rb
@@ -41,7 +41,7 @@ module Decidim
                         .not_hidden
 
           @proposals = @base_query.includes(:component, :coauthorships)
-          @all_geocoded_proposals = @base_query.geocoded
+          @all_geocoded_proposals = @base_query.geocoded.where.not(latitude: Float::NAN, longitude: Float::NAN)
 
           @voted_proposals = if current_user
                                ProposalVote.where(

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -83,6 +83,7 @@ translation:
 # Do not consider these keys missing:
 ignore_missing:
  - faker.*
+ - decidim.proposals.*
 
 # Consider these keys used:
 ignore_unused:

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_04_111121) do
+ActiveRecord::Schema.define(version: 2021_12_04_110567) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2021_12_04_111121) do
   end
 
   create_table "decidim_awesome_config", force: :cascade do |t|
-    t.string "var"
+    t.jsonb "var"
     t.jsonb "value"
     t.integer "decidim_organization_id"
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_04_110567) do
+ActiveRecord::Schema.define(version: 2021_12_04_111121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "ltree"
@@ -265,7 +265,7 @@ ActiveRecord::Schema.define(version: 2021_12_04_110567) do
   end
 
   create_table "decidim_awesome_config", force: :cascade do |t|
-    t.jsonb "var"
+    t.string "var"
     t.jsonb "value"
     t.integer "decidim_organization_id"
     t.datetime "created_at", null: false

--- a/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -1,0 +1,338 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim
+  module Proposals
+    describe ProposalsController, type: :controller do
+      routes { Decidim::Proposals::Engine.routes }
+
+      let(:user) { create(:user, :confirmed, organization: component.organization) }
+
+      let(:proposal_params) do
+        {
+          component_id: component.id
+        }
+      end
+      let(:params) { { proposal: proposal_params } }
+
+      before do
+        request.env["decidim.current_organization"] = component.organization
+        request.env["decidim.current_participatory_space"] = component.participatory_space
+        request.env["decidim.current_component"] = component
+      end
+
+      describe "GET index" do
+        context "when participatory texts are disabled" do
+          let(:component) { create(:proposal_component, :with_geocoding_enabled) }
+
+          it "sorts proposals by search defaults" do
+            get :index
+            expect(response).to have_http_status(:ok)
+            expect(subject).to render_template(:index)
+            expect(assigns(:proposals).order_values).to eq(
+              [
+                Decidim::Proposals::Proposal.arel_table[
+                  Decidim::Proposals::Proposal.primary_key
+                ] * Arel.sql("RANDOM()")
+              ]
+            )
+            expect(assigns(:proposals).order_values.map(&:to_sql)).to eq(
+              ["\"decidim_proposals_proposals\".\"id\" * RANDOM()"]
+            )
+          end
+
+          it "sets two different collections" do
+            geocoded_proposals = create_list :proposal, 10, component: component, latitude: 1.1, longitude: 2.2
+            _non_geocoded_proposals = create_list :proposal, 2, component: component, latitude: nil, longitude: nil
+
+            get :index
+            expect(response).to have_http_status(:ok)
+            expect(subject).to render_template(:index)
+
+            expect(assigns(:proposals).count).to eq 12
+            expect(assigns(:all_geocoded_proposals)).to match_array(geocoded_proposals)
+          end
+        end
+
+        context "when participatory texts are enabled" do
+          let(:component) { create(:proposal_component, :with_participatory_texts_enabled) }
+
+          it "sorts proposals by position" do
+            get :index
+            expect(response).to have_http_status(:ok)
+            expect(subject).to render_template(:participatory_text)
+            expect(assigns(:proposals).order_values.first.expr.name).to eq("position")
+          end
+
+          context "when emendations exist" do
+            let!(:amendable) { create(:proposal, component: component) }
+            let!(:emendation) { create(:proposal, component: component) }
+            let!(:amendment) { create(:amendment, amendable: amendable, emendation: emendation, state: "accepted") }
+
+            it "does not include emendations" do
+              get :index
+              expect(response).to have_http_status(:ok)
+              emendations = assigns(:proposals).select(&:emendation?)
+              expect(emendations).to be_empty
+            end
+          end
+        end
+      end
+
+      describe "GET new" do
+        let(:component) { create(:proposal_component, :with_creation_enabled) }
+
+        before { sign_in user }
+
+        context "when NO draft proposals exist" do
+          it "renders the empty form" do
+            get :new, params: params
+            expect(response).to have_http_status(:ok)
+            expect(subject).to render_template(:new)
+          end
+        end
+
+        context "when draft proposals exist from other users" do
+          let!(:others_draft) { create(:proposal, :draft, component: component) }
+
+          it "renders the empty form" do
+            get :new, params: params
+            expect(response).to have_http_status(:ok)
+            expect(subject).to render_template(:new)
+          end
+        end
+      end
+
+      describe "POST create" do
+        before { sign_in user }
+
+        context "when creation is not enabled" do
+          let(:component) { create(:proposal_component) }
+
+          it "raises an error" do
+            post :create, params: params
+
+            expect(flash[:alert]).not_to be_empty
+          end
+        end
+
+        context "when creation is enabled" do
+          let(:component) { create(:proposal_component, :with_creation_enabled) }
+          let(:proposal_params) do
+            {
+              component_id: component.id,
+              title: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+              body: "Ut sed dolor vitae purus volutpat venenatis. Donec sit amet sagittis sapien. Curabitur rhoncus ullamcorper feugiat. Aliquam et magna metus."
+            }
+          end
+
+          it "creates a proposal" do
+            post :create, params: params
+
+            expect(flash[:notice]).not_to be_empty
+            expect(response).to have_http_status(:found)
+          end
+        end
+      end
+
+      describe "PATCH update" do
+        let(:component) { create(:proposal_component, :with_creation_enabled, :with_attachments_allowed) }
+        let(:proposal) { create(:proposal, component: component, users: [user]) }
+        let(:proposal_params) do
+          {
+            title: "Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+            body: "Ut sed dolor vitae purus volutpat venenatis. Donec sit amet sagittis sapien. Curabitur rhoncus ullamcorper feugiat. Aliquam et magna metus."
+          }
+        end
+        let(:params) do
+          {
+            id: proposal.id,
+            proposal: proposal_params
+          }
+        end
+
+        before { sign_in user }
+
+        it "updates the proposal" do
+          patch :update, params: params
+
+          expect(flash[:notice]).not_to be_empty
+          expect(response).to have_http_status(:found)
+        end
+
+        context "when the existing proposal has attachments and there are other errors on the form" do
+          include_context "with controller rendering the view" do
+            let(:proposal_params) do
+              {
+                title: "Short",
+                # When the proposal has existing photos or documents, their IDs
+                # will be sent as Strings in the form payload.
+                photos: proposal.photos.map { |a| a.id.to_s },
+                documents: proposal.documents.map { |a| a.id.to_s }
+              }
+            end
+            let(:proposal) { create(:proposal, :with_photo, :with_document, component: component, users: [user]) }
+
+            it "displays the editing form with errors" do
+              patch :update, params: params
+
+              expect(flash[:alert]).not_to be_empty
+              expect(response).to have_http_status(:ok)
+              expect(subject).to render_template(:edit)
+              expect(response.body).to include("There was a problem saving")
+            end
+          end
+        end
+      end
+
+      describe "withdraw a proposal" do
+        let(:component) { create(:proposal_component, :with_creation_enabled) }
+
+        before { sign_in user }
+
+        context "when an authorized user is withdrawing a proposal" do
+          let(:proposal) { create(:proposal, component: component, users: [user]) }
+
+          it "withdraws the proposal" do
+            put :withdraw, params: params.merge(id: proposal.id)
+
+            expect(flash[:notice]).to eq("Proposal successfully updated.")
+            expect(response).to have_http_status(:found)
+            proposal.reload
+            expect(proposal.withdrawn?).to be true
+          end
+
+          context "and the proposal already has supports" do
+            let(:proposal) { create(:proposal, :with_votes, component: component, users: [user]) }
+
+            it "is not able to withdraw the proposal" do
+              put :withdraw, params: params.merge(id: proposal.id)
+
+              expect(flash[:alert]).to eq("This proposal can not be withdrawn because it already has supports.")
+              expect(response).to have_http_status(:found)
+              proposal.reload
+              expect(proposal.withdrawn?).to be false
+            end
+          end
+        end
+
+        describe "when current user is NOT the author of the proposal" do
+          let(:current_user) { create(:user, organization: component.organization) }
+          let(:proposal) { create(:proposal, component: component, users: [current_user]) }
+
+          context "and the proposal has no supports" do
+            it "is not able to withdraw the proposal" do
+              expect(WithdrawProposal).not_to receive(:call)
+
+              put :withdraw, params: params.merge(id: proposal.id)
+
+              expect(flash[:alert]).to eq("You are not authorized to perform this action")
+              expect(response).to have_http_status(:found)
+              proposal.reload
+              expect(proposal.withdrawn?).to be false
+            end
+          end
+        end
+      end
+
+      describe "GET show" do
+        let!(:component) { create(:proposal_component, :with_amendments_enabled) }
+        let!(:amendable) { create(:proposal, component: component) }
+        let!(:emendation) { create(:proposal, component: component) }
+        let!(:amendment) { create(:amendment, amendable: amendable, emendation: emendation) }
+        let(:active_step_id) { component.participatory_space.active_step.id }
+
+        context "when the proposal is an amendable" do
+          it "shows the proposal" do
+            get :show, params: params.merge(id: amendable.id)
+            expect(response).to have_http_status(:ok)
+            expect(subject).to render_template(:show)
+          end
+
+          context "and the user is not logged in" do
+            it "shows the proposal" do
+              get :show, params: params.merge(id: amendable.id)
+              expect(response).to have_http_status(:ok)
+              expect(subject).to render_template(:show)
+            end
+          end
+        end
+
+        context "when the proposal is an emendation" do
+          context "and amendments VISIBILITY is set to 'participants'" do
+            before do
+              component.update!(step_settings: { active_step_id => { amendments_visibility: "participants" } })
+            end
+
+            context "when the user is not logged in" do
+              it "redirects to 404" do
+                expect do
+                  get :show, params: params.merge(id: emendation.id)
+                end.to raise_error(ActionController::RoutingError)
+              end
+            end
+
+            context "when the user is logged in" do
+              before { sign_in user }
+
+              context "and the user is the author of the emendation" do
+                let(:user) { amendment.amender }
+
+                it "shows the proposal" do
+                  get :show, params: params.merge(id: emendation.id)
+                  expect(response).to have_http_status(:ok)
+                  expect(subject).to render_template(:show)
+                end
+              end
+
+              context "and is NOT the author of the emendation" do
+                it "redirects to 404" do
+                  expect do
+                    get :show, params: params.merge(id: emendation.id)
+                  end.to raise_error(ActionController::RoutingError)
+                end
+
+                context "when the user is an admin" do
+                  let(:user) { create(:user, :admin, :confirmed, organization: component.organization) }
+
+                  it "shows the proposal" do
+                    get :show, params: params.merge(id: emendation.id)
+                    expect(response).to have_http_status(:ok)
+                    expect(subject).to render_template(:show)
+                  end
+                end
+              end
+            end
+          end
+
+          context "and amendments VISIBILITY is set to 'all'" do
+            before do
+              component.update!(step_settings: { active_step_id => { amendments_visibility: "all" } })
+            end
+
+            context "when the user is not logged in" do
+              it "shows the proposal" do
+                get :show, params: params.merge(id: emendation.id)
+                expect(response).to have_http_status(:ok)
+                expect(subject).to render_template(:show)
+              end
+            end
+
+            context "when the user is logged in" do
+              before { sign_in user }
+
+              context "and is NOT the author of the emendation" do
+                it "shows the proposal" do
+                  get :show, params: params.merge(id: emendation.id)
+                  expect(response).to have_http_status(:ok)
+                  expect(subject).to render_template(:show)
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/decidim/proposals/proposals_controller_spec.rb
+++ b/spec/controllers/decidim/proposals/proposals_controller_spec.rb
@@ -53,6 +53,22 @@ module Decidim
             expect(assigns(:proposals).count).to eq 12
             expect(assigns(:all_geocoded_proposals)).to match_array(geocoded_proposals)
           end
+
+          context "when latitude and longitude are not properly geocoded" do
+            it "doesn't includes it in collection" do
+              geocoded_proposals = create_list :proposal, 10, component: component, latitude: 1.1, longitude: 2.2
+              improperly_geocoded_proposal = create :proposal, component: component, latitude: (0.0 / 0.0), longitude: (0.0 / 0.0)
+              _non_geocoded_proposals = create_list :proposal, 2, component: component, latitude: nil, longitude: nil
+
+              get :index
+              expect(response).to have_http_status(:ok)
+              expect(subject).to render_template(:index)
+
+              expect(assigns(:proposals).count).to eq 13
+              expect(assigns(:all_geocoded_proposals)).to match_array(geocoded_proposals)
+              expect(assigns(:all_geocoded_proposals).include?(improperly_geocoded_proposal)).to eq(false)
+            end
+          end
         end
 
         context "when participatory texts are enabled" do


### PR DESCRIPTION
### Description

Fix bug when latitude or longitude is kind of "NaN" and break the map.

#### To reproduce

* Log in as admin
* Go to admin process
* Enable geocoding on proposals
then
* Create a new proposal with valid address with title "Proposal should be fixed now"
map should work

Then try to reproduce bug using Rails console
* In a new terminal window open rails console `bundle exec rails console`
* In console type `Decidim::Proposals::Proposal.find_by(title: {"en"=>"Proposal should be fixed now"}).update(latitude: 0.0 / 0.0)`
* Then navigate to proposals index page and map should be still displayed