### PR TITLE
Use cache for quicker deploy

### DIFF
--- a/.platform/hooks/postdeploy/upload_assets_to_cache.sh
+++ b/.platform/hooks/postdeploy/upload_assets_to_cache.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -xe
+
+cd /var/app/current
+
+mkdir -p /tmp/cache
+
+tar -zcf /tmp/cache/gem.tar.gz vendor/bundle
+tar -zcf /tmp/cache/node_modules.tar.gz node_modules
+tar -zcf /tmp/cache/assets.tar.gz tmp/cache/assets
+
+aws s3 cp /tmp/cache/gem.tar.gz s3://"${AWS_BUCKET_NAME}"/cache/gem.tar.gz
+aws s3 cp /tmp/cache/node_modules.tar.gz s3://"${AWS_BUCKET_NAME}"/cache/node_modules.tar.gz
+aws s3 cp /tmp/cache/assets.tar.gz s3://"${AWS_BUCKET_NAME}"/cache/assets.tar.gz

--- a/.platform/hooks/prebuild/get_assets_from_cache.sh
+++ b/.platform/hooks/prebuild/get_assets_from_cache.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xe
+
+EB_APP_STAGING_DIR=/var/app/staging
+
+mkdir -p /tmp/cache
+
+if aws s3 ls s3://"${AWS_BUCKET_NAME}"/cache/gem.tar.gz; then
+  aws s3 cp --quiet s3://"${AWS_BUCKET_NAME}"/cache/gem.tar.gz /tmp/cache/gem.tar.gz
+fi
+
+if aws s3 ls s3://"${AWS_BUCKET_NAME}"/cache/node_modules.tar.gz; then
+  aws s3 cp --quiet s3://"${AWS_BUCKET_NAME}"/cache/node_modules.tar.gz /tmp/cache/node_modules.tar.gz
+fi
+
+if aws s3 ls s3://"${AWS_BUCKET_NAME}"/cache/assets.tar.gz; then
+  aws s3 cp --quiet s3://"${AWS_BUCKET_NAME}"/cache/assets.tar.gz /tmp/cache/assets.tar.gz
+fi
+
+[ -f /tmp/cache/gem.tar.gz ] && \
+  tar -xf /tmp/cache/gem.tar.gz -C $EB_APP_STAGING_DIR && \
+  chown webapp:webapp -R "$EB_APP_STAGING_DIR/vendor/bundle"
+
+[ -f /tmp/cache/node_modules.tar.gz ] && \
+  tar -xf /tmp/cache/node_modules.tar.gz -C $EB_APP_STAGING_DIR && \
+  chown webapp:webapp -R "$EB_APP_STAGING_DIR/node_modules"
+
+[ -f /tmp/cache/assets.tar.gz ] && \
+  tar -xf /tmp/cache/assets.tar.gz -C $EB_APP_STAGING_DIR && \
+  chown webapp:webapp -R "$EB_APP_STAGING_DIR/tmp"
+
+exit 0


### PR DESCRIPTION
Allows to upload all forms of assets to speed up the deployment phase.

Must be tested in staging

https://gist.github.com/ssaunier/67b86f628154ede29f16b74608a97240
https://repost.aws/knowledge-center/elastic-beanstalk-platform-hooks