### PR TITLE
Fix/webpack

### DIFF
--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -16,3 +16,8 @@ commands:
         test: "! yarn -v"
     04_yarn_run_install:
         command: yarn install --frozen-lockfile
+container_commands:
+  01_install_webpack:
+    command: npm install --save-dev webpack
+  02_precompile:
+    command: bundle exec rake assets:precompile

--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -3,9 +3,14 @@ packages:
     git: []
     libicu-devel: []
     amazon-linux-extras: []
-    yarn: []
 commands:
     01_postgres_activate:
         command: sudo amazon-linux-extras enable postgresql12
     02_postgres_install:
         command: sudo yum install -y postgresql-libs
+    03_install_yarn:
+        command: |
+            set -e
+            npm i -g yarn
+            ln -s "$(npm bin --global)"/yarn /usr/bin/yarn
+        test: "! yarn -v"

--- a/.ebextensions/01_packages.config
+++ b/.ebextensions/01_packages.config
@@ -8,9 +8,11 @@ commands:
         command: sudo amazon-linux-extras enable postgresql12
     02_postgres_install:
         command: sudo yum install -y postgresql-libs
-    03_install_yarn:
+    03_yarn_install:
         command: |
             set -e
             npm i -g yarn
             ln -s "$(npm bin --global)"/yarn /usr/bin/yarn
         test: "! yarn -v"
+    04_yarn_run_install:
+        command: yarn install --frozen-lockfile


### PR DESCRIPTION
- yum doesn't have yarn by default
- we add a command to install yarn manually via npm
- we add a command to install JS dependencies
- we add a command to install webpack because it was still missing (user visibility I guess)
- we disable to the automatic assets-precompile and add our own command after webpack is available