### PR TITLE
fix warning on sidekiq config file

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,6 @@ group :production do
   gem "sentry-rails"
   gem "sentry-ruby"
   gem "sentry-sidekiq"
-  gem "sidekiq"
-  gem "sidekiq-scheduler"
+  gem "sidekiq", "~> 7.0"
+  gem "sidekiq-scheduler", "~> 5.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1003,8 +1003,8 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  sidekiq
-  sidekiq-scheduler
+  sidekiq (~> 7.0)
+  sidekiq-scheduler (~> 5.0)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)
   sys-filesystem
@@ -1012,7 +1012,7 @@ DEPENDENCIES
   web-console (= 4.0.4)
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 2.7.7p221
 
 BUNDLED WITH
    2.4.6

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,28 +13,29 @@
   - translations
   - metrics
 
-:schedule:
-  CalculateAllMetrics:
-    cron: '0 0 0 * * *' # Run at midnight
-    class: CalculateAllMetricsJob
-    queue: scheduled
-  PreloadOpenData:
-    cron: '0 0 1 * * *' # Run at 01:00
-    class: PreloadOpenDataJob
-    queue: scheduled
-  DetectSpamUsers:
-    cron: '0 0 8 * * *' # Run at 08:00
-    class: Decidim::SpamDetection::MarkUsersJob
-    queue: scheduled
-  #OrdersReminder:
-  #  cron: '0 0 18 * * *' # Run at 18:00
-  #  class: OrdersReminderJob
-  #  queue: scheduled
-  #Backup:
-  #  cron: '0 0 4 * * *' # Run at 04:00
-  #  class: BackupJob
-  #  queue: backups
-  Backup:
-    cron: '0 0 4 * * *' # Run at 04:00
-    class: BackupJob
-    queue: backups
+:scheduler:
+  :schedule:
+    CalculateAllMetrics:
+      cron: '0 0 0 * * *' # Run at midnight
+      class: CalculateAllMetricsJob
+      queue: scheduled
+    PreloadOpenData:
+      cron: '0 0 1 * * *' # Run at 01:00
+      class: PreloadOpenDataJob
+      queue: scheduled
+    DetectSpamUsers:
+      cron: '0 0 8 * * *' # Run at 08:00
+      class: Decidim::SpamDetection::MarkUsersJob
+      queue: scheduled
+    #OrdersReminder:
+    #  cron: '0 0 18 * * *' # Run at 18:00
+    #  class: OrdersReminderJob
+    #  queue: scheduled
+    #Backup:
+    #  cron: '0 0 4 * * *' # Run at 04:00
+    #  class: BackupJob
+    #  queue: backups
+    Backup:
+      cron: '0 0 4 * * *' # Run at 04:00
+      class: BackupJob
+      queue: backups


### PR DESCRIPTION
Fix the warning
`:schedule option should be under the :scheduler: key`
for sidekiq 7.x