### PR TITLE
Downgrade Sidekiq version from 7.0 to 6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,6 @@ group :production do
   gem "sentry-rails"
   gem "sentry-ruby"
   gem "sentry-sidekiq"
-  gem "sidekiq", "~> 7.0"
+  gem "sidekiq", "~> 6.0"
   gem "sidekiq-scheduler", "~> 5.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -397,7 +397,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.0)
+    connection_pool (2.4.1)
     countries (5.4.0)
       unaccent (~> 0.3)
     crack (0.4.5)
@@ -589,6 +589,7 @@ GEM
     mime-types-data (3.2023.0218.1)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.8.2)
     minitest (5.18.0)
     mixlib-cli (2.1.8)
     mixlib-config (3.0.27)
@@ -609,6 +610,9 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.13.4)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.4-x86_64-linux)
@@ -740,8 +744,6 @@ GEM
       wisper (>= 1.6.1)
     redcarpet (3.6.0)
     redis (4.8.1)
-    redis-client (0.14.1)
-      connection_pool
     redlock (1.3.2)
       redis (>= 3.0.0, < 6.0)
     regexp_parser (2.8.0)
@@ -835,11 +837,10 @@ GEM
       sentry-ruby (~> 5.9.0)
       sidekiq (>= 3.0)
     seven_zip_ruby (1.3.0)
-    sidekiq (7.0.9)
-      concurrent-ruby (< 2)
-      connection_pool (>= 2.3.0)
-      rack (>= 2.2.4)
-      redis-client (>= 0.11.0)
+    sidekiq (6.5.8)
+      connection_pool (>= 2.2.5, < 3)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     sidekiq-scheduler (5.0.2)
       rufus-scheduler (~> 3.2)
       sidekiq (>= 6, < 8)
@@ -977,7 +978,7 @@ DEPENDENCIES
   sentry-rails
   sentry-ruby
   sentry-sidekiq
-  sidekiq (~> 7.0)
+  sidekiq (~> 6.0)
   sidekiq-scheduler (~> 5.0)
   spring (~> 2.0)
   spring-watcher-listen (~> 2.0)


### PR DESCRIPTION
#### Description

Sidekiq should be downgraded to `v6.0` to prevent crash with configuration