### PR TITLE
bump zip code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,15 +20,6 @@ gem "decidim-slider", git: "https://github.com/alecslupu-pfa/decidim-module-slid
 gem "decidim-spam_detection"
 gem "decidim-term_customizer", git: "https://github.com/mainio/decidim-module-term_customizer.git", branch: DECIDIM_BRANCH
 
-# PTP_MODULE_VERSION = { github: "Pipeline-to-Power/decidim-module-ptp", branch: "feature/0.26/zip-code-voting" }
-# gem "decidim-ptp", github: "Pipeline-to-Power/decidim-module-ptp", branch: "feature/0.26/zip-code-voting" do
-#   # Rspec:disable Bundler/OrderedGems
-#   gem "decidim-budgets_booth"
-#   gem "decidim-smsauth"
-#   gem "decidim-sms-twilio"
-#   # Rspec:enable Bundler/OrderedGems
-# end
-
 gem "dotenv-rails"
 
 gem "bootsnap", "~> 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GIT
 
 GIT
   remote: https://github.com/Pipeline-to-Power/decidim-module-ptp.git
-  revision: 401ea7ed38f1cbbf011ee08a93ba30db80e41f59
+  revision: 62f71c0ae9cc9a9a2b15c7a155d105f32f05b945
   branch: feature/0.26/zip-code-voting
   specs:
     decidim-budgets_booth (0.26.0)
@@ -630,6 +630,8 @@ GEM
     nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
+    nokogiri (1.13.4-arm64-darwin)
+      racc (~> 1.4)
     oauth (1.1.0)
       oauth-tty (~> 1.0, >= 1.0.1)
       snaky_hash (~> 2.0)
@@ -1002,7 +1004,7 @@ DEPENDENCIES
   web-console (= 4.0.4)
 
 RUBY VERSION
-   ruby 2.7.5p203
+   ruby 2.7.7p221
 
 BUNDLED WITH
    2.3.4


### PR DESCRIPTION
This pr bumps zip code module version.

It also deletes commented gems from the gemfile becaus they are enabled below.