### PR TITLE
fix: Term Customizer does not allow to add new translation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ gem "omniauth-rails_csrf_protection"
 gem "omniauth-saml"
 
 # PTP_MODULE_VERSION = { github: "Pipeline-to-Power/decidim-module-ptp", branch: "feature/0.26/zip-code-voting" }
-gem "decidim-ptp", github: "Pipeline-to-Power/decidim-module-ptp", branch: "feature/0.26/zip-code-voting" do
+gem "decidim-ptp", github: "opensourcepolitics/decidim-module-ptp", branch: "fix/without_l10n_026" do
   # Rspec:disable Bundler/OrderedGems
   gem "decidim-budgets_booth"
   gem "decidim-smsauth"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,29 +36,6 @@ GIT
       decidim-core (~> 0.26)
 
 GIT
-  remote: https://github.com/Pipeline-to-Power/decidim-module-ptp.git
-  revision: 79f07fee09671661ab23e8a8c18e464a78d29966
-  branch: feature/0.26/zip-code-voting
-  specs:
-    decidim-budgets_booth (0.26.0)
-      decidim-budgets (~> 0.26.0)
-      decidim-core (~> 0.26.0)
-    decidim-l10n (0.26.0)
-      decidim-core (~> 0.26.0)
-    decidim-ptp (0.26.0)
-      decidim-budgets_booth (= 0.26.0)
-      decidim-core (~> 0.26.0)
-      decidim-l10n (= 0.26.0)
-      decidim-sms-twilio (= 0.26.0)
-      decidim-smsauth (= 0.26.0)
-    decidim-sms-twilio (0.26.0)
-      decidim-core (~> 0.26.0)
-      twilio-ruby (~> 5.72.0)
-    decidim-smsauth (0.26.0)
-      countries (~> 5.1, >= 5.1.2)
-      decidim-core (~> 0.26.0)
-
-GIT
   remote: https://github.com/alecslupu-pfa/decidim-module-slider
   revision: 1004d0abff85b74e323d00bc14bd2aa35eb0fdce
   branch: main
@@ -82,6 +59,26 @@ GIT
   specs:
     decidim-term_customizer (0.26.0)
       decidim-admin (~> 0.26.0)
+      decidim-core (~> 0.26.0)
+
+GIT
+  remote: https://github.com/opensourcepolitics/decidim-module-ptp.git
+  revision: 16551795a0ef766ddd0df03e149a6b9a5de0fece
+  branch: fix/without_l10n_026
+  specs:
+    decidim-budgets_booth (0.26.0)
+      decidim-budgets (~> 0.26.0)
+      decidim-core (~> 0.26.0)
+    decidim-ptp (0.26.0)
+      decidim-budgets_booth (= 0.26.0)
+      decidim-core (~> 0.26.0)
+      decidim-sms-twilio (= 0.26.0)
+      decidim-smsauth (= 0.26.0)
+    decidim-sms-twilio (0.26.0)
+      decidim-core (~> 0.26.0)
+      twilio-ruby (~> 5.72.0)
+    decidim-smsauth (0.26.0)
+      countries (~> 5.1, >= 5.1.2)
       decidim-core (~> 0.26.0)
 
 GIT

--- a/spec/lib/decidim/term_customizer/translation_directory_spec.rb
+++ b/spec/lib/decidim/term_customizer/translation_directory_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Decidim::TermCustomizer::TranslationDirectory do
+  subject { described_class.new(locale) }
+
+  let(:locale) { :en }
+
+  describe "#backend" do
+    it "returns the correct backend" do
+      expect(subject.backend).to be_a(I18n::Backend::Simple)
+    end
+  end
+
+  describe "#translations" do
+    it "returns a translation store" do
+      expect(subject.translations).to be_a(Decidim::TermCustomizer::TranslationStore)
+    end
+  end
+
+  describe "#translations_search" do
+    it "returns correct translations" do
+      expect(subject.translations_search("term customizer").keys.first).to eq "decidim.decidim_awesome.admin.config.form.help.proposal_custom_fields_translations"
+    end
+  end
+
+  describe "#translations_by_key" do
+    it "does not return any translations for non matching keys" do
+      expect(subject.translations_by_key("term customizer").length).to eq(0)
+    end
+
+    it "returns correct translations" do
+      expect(subject.translations_by_key("term_customizer").length).to eq(75)
+    end
+  end
+
+  describe "#translations_by_term" do
+    it "does not return any translations for non matching terms" do
+      expect(subject.translations_by_term("term_customizer").length).to eq(0)
+    end
+
+    it "returns correct translations" do
+      expect(subject.translations_by_term("term customizer").keys.first).to eq "decidim.decidim_awesome.admin.config.form.help.proposal_custom_fields_translations"
+    end
+  end
+end


### PR DESCRIPTION
#### Description

This PR changes the decidim-ptp from `Pipeline-to-Power` to `OpenSourcePolitics` repository. On this fork `decidim-l10n` is removed from the required dependencies. 

#### Related to

* Fixes issue #58 