### PR TITLE
Fix: Google Translate not displaying on chrome

### DIFF
--- a/app/views/layouts/decidim/_head_extra.html.erb
+++ b/app/views/layouts/decidim/_head_extra.html.erb
@@ -34,20 +34,11 @@
 
     function googleTranslateElementInit() {
       new google.translate.TranslateElement(
-        {
-            pageLanguage: pageLanguage
-        },
-        'google_translate_element'
+          {
+              pageLanguage: autoTargetLanguage
+          },
+          'google_translate_element'
       );
-
-      if (autoTargetLanguage != '' && autoTargetLanguage != pageLanguage ) {
-        waitForElm('#google_translate_element select option[value="' + autoTargetLanguage + '"]').then((gOption) => {
-          var gSelect = gOption.parentNode;
-          gSelect.selectedIndex= gOption.index;
-          gSelect.dispatchEvent(new Event('change'));
-        });
-      }
-
     }
   </script>
   <script src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>


### PR DESCRIPTION
### 🎩 Description

I attempted to remove the "pageLanguage" tag as it appears to be unnecessary. I couldn't find a way to set "autoTargetLanguage" to " ". This may fix the issue of the Google Translate widget not displaying properly. We need to thoroughly verify if this resolves the problem. Otherwise, we'll have to seek an alternative solution if we encounter another issue.

### 📖 Testing

- Prior to initialization, ensure that "TRANSLATION_MODE="google"" is set in your .env file.
- Initialize your application.
- Execute the application.
- Verify if your default browser language is displayed as a translation in the widget.
- Try changing it to various languages.
- Refresh the page.
- Repeat these steps as many times as needed.