### PR TITLE
fix: Fix the display of the language chooser while in cellphone format

### DIFF
--- a/app/packs/stylesheets/decidim/decidim_application.scss
+++ b/app/packs/stylesheets/decidim/decidim_application.scss
@@ -223,3 +223,27 @@ body, h1, h2, h3, h4, h5, h6, p, a, span {
     }
   }
 }
+
+.g-language-choose-medium {
+  .goog-te-gadget {
+    text-indent: -9999px;
+    font-size: 0;
+
+    & > span {
+      display: none;
+    }
+
+    & > div {
+      text-indent: 0;
+    }
+
+    select {
+      font-family: $body-font-family;
+      font-size: 1rem;
+      text-align: center;
+      background-color: transparent;
+      color: var(--secondary);
+      border-color: transparent;
+    }
+  }
+}

--- a/app/views/layouts/decidim/_language_chooser.html.erb
+++ b/app/views/layouts/decidim/_language_chooser.html.erb
@@ -82,4 +82,7 @@
   <div class="topbar__dropmenu language-choose g-language-choose show-for-medium" data-set="language-holder">
     <div class="js-append" id="google_translate_element"></div>
   </div>
+    <div class="g-language-choose-medium hide-for-medium" data-set="language-holder">
+      <div class="js-append" id="google_translate_element"></div>
+    </div>
 <% end %>

--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -22,26 +22,22 @@ end
       </button>
       <!-- Menu -->
       <div class="hide-for-medium" data-set="nav-holder">
-
-      <div class="navbar js-append">
-        <div class="row column">
-          <nav class="main-nav">
-            <ul>
-              <li class="main-nav__link">
-                <a class="main-nav" href="/processes/Citywidepb2023">About</a>
-              </li>
-              <li class="main-nav__link">
-                <a class="main-nav" href="/processes/vote">Election Center</a>
-              </li>
-              <li class="main-nav__link">
-                <%= render partial: "layouts/decidim/language_chooser" %>
-              </li>
-            </ul>
-          </nav>
+        <div class="navbar js-append">
+          <div class="row column">
+            <nav class="main-nav">
+              <ul>
+                <li class="main-nav__link">
+                  <a class="main-nav" href="/processes/Citywidepb2023">About</a>
+                </li>
+                <li class="main-nav__link">
+                  <a class="main-nav" href="/processes/vote">Election Center</a>
+                </li>
+              </ul>
+            </nav>
+          </div>
         </div>
       </div>
 
-      </div>
       <div class="hide-for-medium usermenu-off-canvas-holder"
            data-set="nav-login-holder"></div>
       <div class="hide-for-medium mt-s ml-s mr-s search-off-canvas-holder"
@@ -82,7 +78,6 @@ end
               </div>
 
               <% if current_user %>
-                <%= render partial: "layouts/decidim/language_chooser" %>
                 <%= render partial: "layouts/decidim/social_media_links" %>
                 <%= render partial: "layouts/decidim/admin_links" %>
                 <nav class="topbar__dropmenu topbar__user__logged" aria-label="<%= t("layouts.decidim.header.user_menu") %>">
@@ -107,8 +102,10 @@ end
                         <!-- Repeated due to dropdown limitations -->
                         <ul class="menu is-dropdown-submenu js-append usermenu-off-canvas">
                           <%= render partial: "layouts/decidim/user_menu" %>
-
                         </ul>
+                        <div class="js-append">
+                          <%= render partial: "layouts/decidim/language_chooser" %>
+                        </div>
                       </div>
                     </li>
                   </ul>
@@ -118,8 +115,10 @@ end
                   <div class="topbar__user__login js-append">
                     <%= link_to t("layouts.decidim.header.sign_in"), decidim.new_user_session_path, class: "sign-in-link" %>
                   </div>
+                  <div class="js-append">
+                    <%= render partial: "layouts/decidim/language_chooser" %>
+                  </div>
                 </div>
-                <%= render partial: "layouts/decidim/language_chooser" %>
                 <%= render partial: "layouts/decidim/social_media_links" %>
                 <%= render partial: "layouts/decidim/admin_links" %>
               <% end %>

--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -78,6 +78,9 @@ end
               </div>
 
               <% if current_user %>
+                <div class="topbar__dropmenu language-choose g-language-choose show-for-medium" data-set="language-holder">
+                  <div class="js-append" id="google_translate_element"></div>
+                </div>
                 <%= render partial: "layouts/decidim/social_media_links" %>
                 <%= render partial: "layouts/decidim/admin_links" %>
                 <nav class="topbar__dropmenu topbar__user__logged" aria-label="<%= t("layouts.decidim.header.user_menu") %>">
@@ -103,12 +106,13 @@ end
                         <ul class="menu is-dropdown-submenu js-append usermenu-off-canvas">
                           <%= render partial: "layouts/decidim/user_menu" %>
                         </ul>
-                        <div class="js-append">
-                          <%= render partial: "layouts/decidim/language_chooser" %>
-                        </div>
+                      <div class="js-append hide-for-medium">
+                        <%= render partial: "layouts/decidim/language_chooser" %>
+                      </div>
                       </div>
                     </li>
                   </ul>
+
                 </nav>
               <% else %>
                 <div class="topbar__user show-for-medium" data-set="nav-login-holder">


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This PR is made to fix the display of the language chooser -> It was not displayed when we were on smartphone so it must be fixed now

NB: The design was not properly handled by myself so it may need some refactor afterwards.

#### :pushpin: Related Issues
*Link your PR to an issue*
- [Notion card](https://www.notion.so/opensourcepolitics/BUG-NY-Affichage-du-hamburger-menu-et-langues-en-mobile-et-desktop-aaf0a46d56d8499ba929f1a7bf3ead35?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Before initializing your app please add to your .env the following line
```
TRANSLATION_MODE="google"
```
* Initialize your app
* On your browser, put yourself in responsive mode following those steps
```
right click
inspect
clicking on the smartphone/tablet icons
```
* Select any item you want in the list
* Open your menu
* Check if translation is there
* Log in 
* Same steps than above

#### Tasks
- [ ] Add specs
- [ ] Add note about overrides in OVERLOADS.md
- [ ] In case of new dependencies or version bump, update related documentation

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
