### PR TITLE
fix: warning on gems dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,8 @@ gem "decidim-term_customizer", git: "https://github.com/opensourcepolitics/decid
 
 # PTP_MODULE_VERSION = { github: "Pipeline-to-Power/decidim-module-ptp", branch: "feature/0.26/zip-code-voting" }
 gem "decidim-budgets_booth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "feature/0.26/zip-code-voting"
-gem "decidim-smsauth", github: "Pipeline-to-Power/decidim-module-ptp", branch: "feature/0.26/zip-code-voting"
-gem "decidim-sms-twilio", github: "Pipeline-to-Power/decidim-module-ptp", branch: "feature/0.26/zip-code-voting"
+gem "decidim-smsauth", github: "OpenSourcePolitics/decidim-module-ptp", branch: "feature/0.26/zip-code-voting"
+gem "decidim-sms-twilio", github: "OpenSourcePolitics/decidim-module-ptp", branch: "feature/0.26/zip-code-voting"
 
 # NOTE: Custom proposal states must be before simple_proposal
 gem "decidim-custom_proposal_states", git: "https://github.com/alecslupu-pfa/decidim-module-custom_proposal_states", branch: "chore/fix-module-dependency"
@@ -41,6 +41,7 @@ gem "uglifier", "~> 4.1"
 
 gem "faker", "~> 2.14"
 
+gem "net-http"
 gem "nokogiri", "1.13.4"
 
 gem "activejob-uniqueness", require: "active_job/uniqueness/sidekiq_patch"

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem "faker", "~> 2.14"
 
 gem "net-http"
 gem "nokogiri", "1.13.4"
+gem "uri", "0.10.0"
 
 gem "activejob-uniqueness", require: "active_job/uniqueness/sidekiq_patch"
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -935,7 +935,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unaccent (0.4.0)
     unicode-display_width (1.8.0)
-    uri (0.13.0)
+    uri (0.10.0)
     valid_email2 (2.3.1)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -1036,10 +1036,11 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0)
   sys-filesystem
   uglifier (~> 4.1)
+  uri (= 0.10.0)
   web-console (= 4.0.4)
 
 RUBY VERSION
    ruby 2.7.7p221
 
 BUNDLED WITH
-   2.3.4
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,12 @@ GIT
     decidim-budgets_booth (0.26.0)
       decidim-budgets (~> 0.26.0)
       decidim-core (~> 0.26.0)
+    decidim-sms-twilio (0.26.0)
+      decidim-core (~> 0.26.0)
+      twilio-ruby (~> 5.72.0)
+    decidim-smsauth (0.26.0)
+      countries (~> 5.1, >= 5.1.2)
+      decidim-core (~> 0.26.0)
 
 GIT
   remote: https://github.com/OpenSourcePolitics/decidim-module_phone_authorization_handler
@@ -35,18 +41,6 @@ GIT
   specs:
     decidim-phone_authorization_handler (1.0.0)
       decidim-core (~> 0.26)
-
-GIT
-  remote: https://github.com/Pipeline-to-Power/decidim-module-ptp.git
-  revision: 79f07fee09671661ab23e8a8c18e464a78d29966
-  branch: feature/0.26/zip-code-voting
-  specs:
-    decidim-sms-twilio (0.26.0)
-      decidim-core (~> 0.26.0)
-      twilio-ruby (~> 5.72.0)
-    decidim-smsauth (0.26.0)
-      countries (~> 5.1, >= 5.1.2)
-      decidim-core (~> 0.26.0)
 
 GIT
   remote: https://github.com/alecslupu-pfa/decidim-module-custom_proposal_states
@@ -648,6 +642,8 @@ GEM
     multi_json (1.15.0)
     multi_xml (0.6.0)
     mustache (1.1.1)
+    net-http (0.4.1)
+      uri
     net-imap (0.3.4)
       date
       net-protocol
@@ -939,6 +935,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unaccent (0.4.0)
     unicode-display_width (1.8.0)
+    uri (0.13.0)
     valid_email2 (2.3.1)
       activemodel (>= 3.2)
       mail (~> 2.5)
@@ -1020,6 +1017,7 @@ DEPENDENCIES
   letter_opener_web (~> 1.3)
   listen (~> 3.1)
   lograge
+  net-http
   nokogiri (= 1.13.4)
   omniauth-rails_csrf_protection
   omniauth-saml


### PR DESCRIPTION
- net-http : 
```
/var/app/staging/vendor/bundle/ruby/2.7.0/gems/net-protocol-0.2.1/lib/net/protocol.rb:68: warning: already initialized constant Net::ProtocRetryError
/opt/rubies/ruby-2.7.7/lib/ruby/2.7.0/net/protocol.rb:66: warning: previous definition of ProtocRetryError was here
/var/app/staging/vendor/bundle/ruby/2.7.0/gems/net-protocol-0.2.1/lib/net/protocol.rb:214: warning: already initialized constant Net::BufferedIO::BUFSIZE
/opt/rubies/ruby-2.7.7/lib/ruby/2.7.0/net/protocol.rb:206: warning: previous definition of BUFSIZE was here
/var/app/staging/vendor/bundle/ruby/2.7.0/gems/net-protocol-0.2.1/lib/net/protocol.rb:541: warning: already initialized constant Net::NetPrivate::Socket
/opt/rubies/ruby-2.7.7/lib/ruby/2.7.0/net/protocol.rb:503: warning: previous definition of Socket was here
```
- harmonize source for `decidim-module-ptp`
```
Warning: The gem 'decidim-l10n' was found in multiple relevant sources.
  * https://github.com/OpenSourcePolitics/decidim-module-ptp.git (at feature/0.26/zip-code-voting@6148a81)
  * https://github.com/Pipeline-to-Power/decidim-module-ptp.git (at feature/0.26/zip-code-voting@79f07fe)
You should add this gem to the source block for the source you wish it to be installed from.
Warning: The gem 'decidim-ptp' was found in multiple relevant sources.
  * https://github.com/OpenSourcePolitics/decidim-module-ptp.git (at feature/0.26/zip-code-voting@6148a81)
  * https://github.com/Pipeline-to-Power/decidim-module-ptp.git (at feature/0.26/zip-code-voting@79f07fe)
You should add this gem to the source block for the source you wish it to be installed from.
```