### PR TITLE
Refactor language selector for consistent accessibility

### DIFF
--- a/app/views/layouts/decidim/_wrapper.html.erb
+++ b/app/views/layouts/decidim/_wrapper.html.erb
@@ -60,6 +60,9 @@ end
               <div class="logo-wrapper">
                 <%= render partial: "layouts/decidim/logo", locals: { organization: current_organization } %>
               </div>
+              <div class="topbar__dropmenu language-choose g-language-choose" data-set="language-holder">
+                <div class="js-append" id="google_translate_element"></div>
+              </div>
               <div class="hide-for-medium topbar__menu">
                 <button type="button" data-toggle="offCanvas" aria-label="<%= t("layouts.decidim.header.navigation") %>">
                   <%= icon "menu", aria_label: t("layouts.decidim.header.navigation"), role: "img" %>
@@ -77,10 +80,9 @@ end
                   </div>
               </div>
 
+
+
               <% if current_user %>
-                <div class="topbar__dropmenu language-choose g-language-choose show-for-medium" data-set="language-holder">
-                  <div class="js-append" id="google_translate_element"></div>
-                </div>
                 <%= render partial: "layouts/decidim/social_media_links" %>
                 <%= render partial: "layouts/decidim/admin_links" %>
                 <nav class="topbar__dropmenu topbar__user__logged" aria-label="<%= t("layouts.decidim.header.user_menu") %>">


### PR DESCRIPTION
The Google Translate element has been relocated to the main topbar for consistent visibility across all device views. Previously, the language selector was only accessible within the off-canvas menu, which could be hidden on smaller devices. Now, it has been moved out of the off-canvas to the main topbar, ensuring that language selection is always available to the user.