### PR TITLE
Fix: decidim-template-dependency

### DIFF
--- a/OVERLOADS.md
+++ b/OVERLOADS.md
@@ -127,3 +127,6 @@ de6d804 - fix multipart object tagging (#40) (#41), 2021-12-24
 
 * `lib/tasks/restore_dump.rake`
 705e0ad - Run rubocop, 2021-12-01
+
+* `app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb`
+Local backport of https://github.com/decidim/decidim/commit/420623d647d2020665cfbaa118514f5e92672c68

--- a/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
+++ b/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+module Decidim
+  module Forms
+    module Admin
+      module Concerns
+        # Questionnaires can be related to any class in Decidim, in order to
+        # manage the questionnaires for a given type, you should create a new
+        # controller and include this concern.
+        #
+        # The only requirement is to define a `questionnaire_for` method that
+        # returns an instance of the model that questionnaire belongs to.
+        module HasQuestionnaire
+          extend ActiveSupport::Concern
+
+          included do
+            helper Decidim::Forms::Admin::ApplicationHelper
+            include Decidim::TranslatableAttributes
+
+            helper_method :questionnaire_for, :questionnaire, :blank_question, :blank_answer_option, :blank_matrix_row,
+                          :blank_display_condition, :question_types, :display_condition_types, :update_url, :public_url, :answer_options_url, :edit_questionnaire_title
+
+            if defined?(Decidim::Templates::Admin::Concerns::Templatable)
+              include Decidim::Templates::Admin::Concerns::Templatable
+              helper Decidim::Templates::Admin::TemplatesHelper
+
+              def templatable_type
+                "Decidim::Forms::Questionnaire"
+              end
+
+              def templatable
+                questionnaire
+              end
+            end
+
+            def edit
+              enforce_permission_to :update, :questionnaire, questionnaire: questionnaire
+
+              @form = form(Admin::QuestionnaireForm).from_model(questionnaire)
+
+              render template: "decidim/forms/admin/questionnaires/edit"
+            end
+
+            def update
+              enforce_permission_to :update, :questionnaire, questionnaire: questionnaire
+
+              params["published_at"] = Time.current if params.has_key? "save_and_publish"
+              @form = form(Admin::QuestionnaireForm).from_params(params)
+
+              Admin::UpdateQuestionnaire.call(@form, questionnaire) do
+                on(:ok) do
+                  # i18n-tasks-use t("decidim.forms.admin.questionnaires.update.success")
+                  flash[:notice] = I18n.t("update.success", scope: i18n_flashes_scope)
+                  redirect_to after_update_url
+                end
+
+                on(:invalid) do
+                  # i18n-tasks-use t("decidim.forms.admin.questionnaires.update.invalid")
+                  flash.now[:alert] = I18n.t("update.invalid", scope: i18n_flashes_scope)
+                  render template: "decidim/forms/admin/questionnaires/edit"
+                end
+              end
+            end
+
+            def answer_options
+              respond_to do |format|
+                format.json do
+                  question_id = params["id"]
+                  question = Question.find_by(id: question_id)
+                  render json: question.answer_options.map { |answer_option| AnswerOptionPresenter.new(answer_option).as_json } if question.present?
+                end
+              end
+            end
+
+            # Public: The only method to be implemented at the controller. You need to
+            # return the object that will hold the questionnaire.
+            def questionnaire_for
+              raise "#{self.class.name} is expected to implement #questionnaire_for"
+            end
+
+            # You can implement this method in your controller to change the URL
+            # where the questionnaire will be submitted.
+            def update_url
+              url_for(questionnaire.questionnaire_for)
+            end
+
+            # You can implement this method in your controller to change the URL
+            # where the user will be redirected after updating the questionnaire
+            def after_update_url
+              url_for(questionnaire.questionnaire_for)
+            end
+
+            # Implement this method in your controller to set the URL
+            # where the questionnaire can be answered.
+            def public_url
+              raise "#{self.class.name} is expected to implement #public_url"
+            end
+
+            # Returns the url to get the answer options json (for the display conditions form)
+            # for the question with id = params[:id]
+            def answer_options_url(params)
+              url_for([questionnaire.questionnaire_for, { action: :answer_options, format: :json, **params }])
+            end
+
+            # Implement this method in your controller to set the title
+            # of the edit form.
+            def edit_questionnaire_title
+              t(:title, scope: "decidim.forms.admin.questionnaires.form", questionnaire_for: translated_attribute(questionnaire_for.try(:title)))
+            end
+
+            private
+
+            def i18n_flashes_scope
+              "decidim.forms.admin.questionnaires"
+            end
+
+            def questionnaire
+              @questionnaire ||= Questionnaire.find_by(questionnaire_for: questionnaire_for)
+            end
+
+            def blank_question
+              @blank_question ||= Admin::QuestionForm.new
+            end
+
+            def blank_answer_option
+              @blank_answer_option ||= Admin::AnswerOptionForm.new
+            end
+
+            def blank_display_condition
+              @blank_display_condition ||= Admin::DisplayConditionForm.new
+            end
+
+            def blank_matrix_row
+              @blank_matrix_row ||= Admin::QuestionMatrixRowForm.new
+            end
+
+            def question_types
+              @question_types ||= Question::QUESTION_TYPES.map do |question_type|
+                [question_type, I18n.t("decidim.forms.question_types.#{question_type}")]
+              end
+            end
+
+            def display_condition_types
+              @display_condition_types ||= DisplayCondition.condition_types.keys.map do |condition_type|
+                [condition_type, I18n.t("decidim.forms.admin.questionnaires.display_condition.condition_types.#{condition_type}")]
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Backport of : 
https://github.com/decidim/decidim/commit/420623d647d2020665cfbaa118514f5e92672c68

## Issue : 
When launching in `production` mode,  this error occurs : 
```
% bundle exec rails c -e production
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
WickedPdf.config= is deprecated and will be removed in future versions. Use WickedPdf.configure instead.
Traceback (most recent call last):
        63: from bin/rails:6:in `<main>'
        62: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        61: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        60: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/commands.rb:18:in `<main>'
        59: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/command.rb:46:in `invoke'
        58: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/command/base.rb:69:in `perform'
        57: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
        56: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
        55: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
        54: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/commands/console/console_command.rb:101:in `perform'
        53: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/command/actions.rb:15:in `require_application_and_environment!'
        52: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/command/actions.rb:28:in `require_environment!'
        51: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/application.rb:339:in `require_environment!'
        50: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/dependencies.rb:324:in `require'
        49: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/dependencies.rb:291:in `load_dependency'
        48: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/dependencies.rb:324:in `block in require'
        47: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:34:in `require'
        46: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
        45: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        44: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
        43: from /Users/decidim/dev/pro/aws/decidim-nyc/config/environment.rb:7:in `<main>'
        42: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/application.rb:363:in `initialize!'
        41: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/initializable.rb:60:in `run_initializers'
        40: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:205:in `tsort_each'
        39: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:226:in `tsort_each'
        38: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:347:in `each_strongly_connected_component'
        37: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:347:in `call'
        36: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:347:in `each'
        35: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:349:in `block in each_strongly_connected_component'
        34: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:431:in `each_strongly_connected_component_from'
        33: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component'
        32: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/2.7.0/tsort.rb:228:in `block in tsort_each'
        31: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/initializable.rb:61:in `block in run_initializers'
        30: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/initializable.rb:32:in `run'
        29: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/initializable.rb:32:in `instance_exec'
        28: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/railties-6.0.6.1/lib/rails/application/finisher.rb:122:in `block in <module:Finisher>'
        27: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader.rb:377:in `eager_load_all'
        26: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader.rb:377:in `each'
        25: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader.rb:379:in `block in eager_load_all'
        24: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
        23: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
        22: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
        21: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:16:in `each'
        20: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
        19: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:170:in `actual_eager_load_dir'
        18: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:25:in `ls'
        17: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:25:in `each'
        16: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:40:in `block in ls'
        15: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/eager_load.rb:175:in `block in actual_eager_load_dir'
        14: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:135:in `cget'
        13: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/loader/helpers.rb:135:in `const_get'
        12: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/zeitwerk-2.6.13/lib/zeitwerk/kernel.rb:26:in `require'
        11: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/polyglot-0.3.5/lib/polyglot.rb:65:in `require'
        10: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
         9: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
         8: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/decidim-surveys-0.26.9/app/controllers/decidim/surveys/admin/surveys_controller.rb:3:in `<main>'
         7: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/decidim-surveys-0.26.9/app/controllers/decidim/surveys/admin/surveys_controller.rb:4:in `<module:Decidim>'
         6: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/decidim-surveys-0.26.9/app/controllers/decidim/surveys/admin/surveys_controller.rb:5:in `<module:Surveys>'
         5: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/decidim-surveys-0.26.9/app/controllers/decidim/surveys/admin/surveys_controller.rb:7:in `<module:Admin>'
         4: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/decidim-surveys-0.26.9/app/controllers/decidim/surveys/admin/surveys_controller.rb:8:in `<class:SurveysController>'
         3: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/decidim-surveys-0.26.9/app/controllers/decidim/surveys/admin/surveys_controller.rb:8:in `include'
         2: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/concern.rb:122:in `append_features'
         1: from /Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/activesupport-6.0.6.1/lib/active_support/concern.rb:122:in `class_eval'
/Users/decidim/.rbenv/versions/2.7.7/lib/ruby/gems/2.7.0/gems/decidim-forms-0.26.9/app/controllers/decidim/forms/admin/concerns/has_questionnaire.rb:24:in `block in <module:HasQuestionnaire>': uninitialized constant Decidim::Templates::Admin::Concerns (NameError)
Did you mean?  Decidim::Conferences
```