### PR TITLE
Update _language_chooser.html.erb

### DIFF
--- a/app/views/layouts/decidim/_language_chooser.html.erb
+++ b/app/views/layouts/decidim/_language_chooser.html.erb
@@ -82,7 +82,4 @@
   <div class="topbar__dropmenu language-choose g-language-choose show-for-medium" data-set="language-holder">
     <div class="js-append" id="google_translate_element"></div>
   </div>
-    <div class="g-language-choose-medium hide-for-medium" data-set="language-holder">
-      <div class="js-append" id="google_translate_element"></div>
-    </div>
 <% end %>


### PR DESCRIPTION
Because of the hide-for-medium, the language chooser would still appear in the hamburger menu on mobile. Without this code snippet, it behaves as it should - always be visible in the navbar.